### PR TITLE
Add go-rpm-release recipe and docker image of same

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@
 
 # Output of the go coverage tool, specifically when used with LiteIDE
 *.out
+
+*.tar.gz

--- a/cookbook.yml
+++ b/cookbook.yml
@@ -1,2 +1,3 @@
 recipes:
   - go-github-release
+  - go-rpm-release

--- a/images/rpm-build/Dockerfile
+++ b/images/rpm-build/Dockerfile
@@ -1,0 +1,18 @@
+FROM golang:1.11-alpine3.8
+
+RUN apk add --no-cache bash \
+                       build-base \
+                       curl \
+                       git \
+                       rpm
+
+RUN go get -u github.com/golang/dep/cmd/dep
+
+WORKDIR /app
+
+ARG GORELEASER_VERSION=v0.112.2
+
+RUN curl -L -o goreleaser.tgz \
+      https://github.com/goreleaser/goreleaser/releases/download/${GORELEASER_VERSION}/goreleaser_Linux_x86_64.tar.gz && \
+      tar -zxvf goreleaser.tgz -C /usr/local/bin/ && \
+      rm -f goreleaser.tgz

--- a/recipes/go-rpm-release/.dunner.yaml
+++ b/recipes/go-rpm-release/.dunner.yaml
@@ -1,0 +1,8 @@
+go-rpm-release: 
+  - image: apoorvam6/go-rpm-release:v1.0.0 
+    commands:
+    - ["goreleaser", "release", "--rm-dist"]
+    mounts:
+    - ".:/app"
+    envs:
+    - GITHUB_TOKEN=`$GITHUB_TOKEN`

--- a/recipes/go-rpm-release/.goreleaser.yml
+++ b/recipes/go-rpm-release/.goreleaser.yml
@@ -1,0 +1,19 @@
+# For more on configuration options, check http://goreleaser.com
+project_name: <your_project_name>
+
+builds:
+- goos:
+    - linux
+  goarch:
+    - 386
+    - amd64
+
+nfpms:
+-
+  name_template: "{{ .ProjectName }}_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+  homepage:  <homepage>
+  description: <short_description>
+  maintainer: <maintainer>
+  license: <license>
+  formats:
+  - rpm

--- a/recipes/go-rpm-release/README.md
+++ b/recipes/go-rpm-release/README.md
@@ -1,0 +1,19 @@
+# go-rpm-release
+
+This recipe creates a dunner task file `.dunner.yaml` and also `.goreleaser.yml` which contains rpm package information. Edit it accordingly and set environment variable `GITHUB_TOKEN`.
+
+To set the version of your project add git tag and push it to master branch remote. 
+
+```
+$ git tag -a <version> -m "Release version <version>"
+$ git push origin <version>
+```
+
+Running below command will build the rpm package, binaries/archives by default for linux and publish them as Github release. 
+
+```
+$ dunner do go-rpm-build
+```
+
+You can customize target OS/Arch. Check http://goreleaser.com for more configurations.
+If you wish to skip publish and try out locally, pass `--skip-publish` flag for goreleaser in `.goreleaser.yml` file.

--- a/recipes/go-rpm-release/metadata.yml
+++ b/recipes/go-rpm-release/metadata.yml
@@ -1,0 +1,24 @@
+name: go-rpm-release
+description: "Dunner recipe to build and release rpm package for Golang projects"
+version: "0.0.1"
+
+preInstallCmd: "curl -O https://raw.githubusercontent.com/leopardlabs/dunner-cookbook/master/recipes/go-rpm-release/.goreleaser.yml"
+
+postInstallMessage: |
+    This recipe creates a dunner task file `.dunner.yaml` and also `.goreleaser.yml` which contains rpm package information. 
+    Edit it accordingly and set environment variable `GITHUB_TOKEN`.
+    
+    To set the version of your project add git tag and push it to master branch remote. 
+    
+    ```
+    $ git tag -a <version> -m "Release version <version>"
+    $ git push origin <version>
+    ```
+    
+    Running below command will build the rpm package, binaries/archives by default for linux and publish them as Github release. You can customize target OS/Arch.
+    Check http://goreleaser.com for more configurations.
+    If you wish to skip publish and try out locally, pass `--skip-publish` flag for goreleaser in `.goreleaser.yml` file.
+    
+    ```
+    $ dunner do go-rpm-build
+    ```


### PR DESCRIPTION
`dunner init go-rpm-release`

This recipe is for go projects to build and release rpm packages using goreleaser. Have build a docker image for same. Its currently available here: https://hub.docker.com/r/apoorvam6/go-rpm-release, happy to move it to leopardslab org in docker hub, if one can be created. 